### PR TITLE
Bug in showCmdScript.php - $status will never match

### DIFF
--- a/lib/showCmdScript.php
+++ b/lib/showCmdScript.php
@@ -85,7 +85,7 @@ if (!empty($getNodes)) {
         // ok, verification of host reachability based on fsockopen to host port i.e. 22 or 23. If fails, continue to next foreach iteration		
         $status = getHostStatus($device['deviceIpAddr'], $device['connPort']); // getHostStatus() from functions.php 
 
-        if ($status === "<font color=red>Unavailable</font>") {
+        if (preg_match("/Unavailable/", $status) === 1) {
             $text = "Failure: Unable to connect to " . $device['deviceName'] . " - " . $device['deviceIpAddr'] . " when running taskID " . $tid;
             $report->eachData($device['deviceName'], $connStatusFail, $text); // log to report
             echo $text . " - getHostStatus() Error:(File: " . $_SERVER['PHP_SELF'] . ")\n"; // log to console


### PR DESCRIPTION
$status will never be equal to `'<font color=red>Unavailable</font>'` because getHostStatus() returns `'<font color="red">Unavailable</font>'`, ie: the color quoted.
Proposed change makes the code simpler and fixes this bug
