### PR TITLE
Make Report display properly on most mail clients

### DIFF
--- a/classes/reportTemplate.class.php
+++ b/classes/reportTemplate.class.php
@@ -130,25 +130,35 @@ $compareTableCss
         <h1><span id="title">$title</span></h1>
     </div>
      <div id="content">
-        <div style="float: left;" id="summDiv">
-            <b>Report Name:</b><br/>
-            <b>Report Date:</b><br/>
-            <b>ScriptName:</b><br/>
-            <b>Task ID:</b><br/>
-            <b>Task Start Time:</b><br/>
-            <b>Task End Time:</b><br/>
-            <b>Task Run Time:</b><br/>
-        </div>
-        <div style="float: left;" id="summDiv">
-            $reportName<br/>
-            $this->reportDate<br/>
-            $scriptName<br/>
-            $taskid<br/>
-            $taskStartTime<br/>
-            <taskEndTime><br/>
-            <taskRunTime><br/>
-        </div>
-        <div style="float: right;"  id="summDiv"><img src="$logo" alt="rConfig" title="rConfig"></div>
+        <table id="theader" summary="Report Metadata"> 
+          <tr>
+            <td>
+	      <div style="float: left; font-weight: bold" id="leftinf">
+                Report Name:<br/>
+                Report Date:<br/>
+                ScriptName:<br/>
+                Task ID:<br/>
+                Task Start Time:<br/>
+                Task End Time:<br/>
+                Task Run Time:<br/>
+              </div>
+            </td>
+            <td> 
+              <div style="float: left;" id="rightinf">
+                $reportName<br/>
+                $this->reportDate<br/>
+                $scriptName<br/>
+                $taskid<br/>
+                $taskStartTime<br/>
+                <taskEndTime><br/>
+                <taskRunTime><br/>
+              </div>
+            </td>
+            <td>
+              <div style="float: right;"  id="summDiv"><img src="$logo" alt="rConfig" title="rConfig" /></div>
+	    </td>
+          </tr>
+	</table>
         <div style="clear:both"> </div>
         <hr/>
 EOF;
@@ -312,7 +322,7 @@ EOF;
 	 </div>
 	 <div style="clear:both;"></div>
 		 <div id="footer">
-			   &copy rConfig	
+			   &copy; rConfig	
 	     </div>   
 	</div>
 </body>

--- a/www/CHANGELOG
+++ b/www/CHANGELOG
@@ -1,3 +1,8 @@
+Version 3.6.9
+30-Aug-2016
+Author: Jose Diaz
+        Fixed - Make task e-mail reports display properly with different e-mail client programs, specially Outlook.
+
 Version 3.6.8
 28-Aug-2016
 Author: Jose Diaz


### PR DESCRIPTION
Use HTML table to make the report header display properly on mail clients that do not implement CSS correctly (for example Outlook 2010).  Without this change, the variable data may not be correctly aligned to the labels. In iPhone look fine, but in Outlook 2010 we get 7 rows (Report Name, Report Date, ... Task Run Time) and then 7 additional rows with the variable data (My Report, Tue 30 Aug 2016, .... 2 Seconds). 
Tidy HTML tags (copyright, img).
