### PR TITLE
Telnet Template with no Username

### DIFF
--- a/templates/ios-telnet-enable-no-username.yml
+++ b/templates/ios-telnet-enable-no-username.yml
@@ -1,0 +1,49 @@
+# rConfig connection template - DO NOT EDIT DIRECTLY
+## Notes: 
+    ## Remember to update permissions for the templates folder after uploading new template files.
+    ## run 'chown -R apache /home/rconfig' on your rconfig server CLI
+    ## all items below that contain free text should be contained within quotation marks " "
+    ## For new community submitted templates visit: https://github.com/rconfig/rConfig-templates
+
+main:
+  name: "Cisco IOS - TELNET - Enable"
+  desc: "Cisco IOS TELNET based connection with enable mode"
+connect:
+  # connection timeout in seconds
+  timeout: 60
+  # type either telnet or ssh - must be in lowercase
+  protocol: telnet
+  # type port number for connection protocol choose from 1 - 65535
+  port: 23
+auth:
+  # Set username name prompt. Must be in quotes. If left blank, username will not be sent.
+  username: ""
+  # Set password name prompt. Must be in quotes
+  password: "Password:"
+  # Set enable mode on or off
+  enable: on
+  # set enable mode command. Must be in quotes
+  enableCmd: "enable"
+  # set enable mode password prompt. Must be in quotes
+  enablePassPrmpt: "Password:"
+  # set HP 'press any key' status. Is 'on' or 'off'
+  hpAnyKeyStatus: off
+  # set HP 'press any key' prompt. 
+  hpAnyKeyPrmpt: "Press any key to continue"  
+config:
+    # Experimental: Some vendors use different linebreak settings. Choose 'n' (default) or 'r'
+    linebreak: "n"
+    # Disable config scrolling/ paging command. on/off
+    paging: on
+    # Disable config scrolling/ paging command. Leave blank, or set as required. Must place command in quotations
+    pagingCmd: "terminal length 0"
+    # re-enable config scrolling/ paging command. Leave blank, or set as required. Must place command in quotations
+    resetPagingCmd: "terminal length 40"
+    # Set pager prompt. Must place command in quotations
+    pagerPrompt: "--More--"
+    # Set pager prompt key-stroke. Must place command in quotations
+    pagerPromptCmd: " "
+    # Save configuration command. Leave blank, or set as required. Must be in quotes
+    saveConfig: "wr mem"
+    # Set exit command. Must place command in quotations
+    exitCmd: "quit"

--- a/templates/ios-telnet-enable-no-username.yml
+++ b/templates/ios-telnet-enable-no-username.yml
@@ -6,8 +6,8 @@
     ## For new community submitted templates visit: https://github.com/rconfig/rConfig-templates
 
 main:
-  name: "Cisco IOS - TELNET - Enable"
-  desc: "Cisco IOS TELNET based connection with enable mode"
+  name: "Cisco IOS - TELNET - Enable - No Username"
+  desc: "Cisco IOS TELNET based connection with enable mode and no username"
 connect:
   # connection timeout in seconds
   timeout: 60


### PR DESCRIPTION
Adding a default template with no user name.  We use this commonly and it takes me a while to figure it out so I think it would beneficial to have one.