### PR TITLE
fixing non well numeric value

### DIFF
--- a/config/functions.inc.php
+++ b/config/functions.inc.php
@@ -186,6 +186,9 @@ function fileRead($filename) {
 function get_memory_free() {
     foreach (file('/proc/meminfo') as $ri)
         $m[strtok($ri, ':')] = strtok('');
+	foreach($m as $key => $value){
+		$m[$key = trim(str_replace(" kB","",$value));
+	}	
     return 100 - round(($m['MemFree'] + $m['Buffers'] + $m['Cached']) / $m['MemTotal'] * 100);
 }
 

--- a/config/functions.inc.php
+++ b/config/functions.inc.php
@@ -200,7 +200,7 @@ function get_memory_free() {
 function get_memory_total() {
     foreach (file('/proc/meminfo') as $ri)
         $m[strtok($ri, ':')] = strtok('');
-    return round(substr($m['MemTotal'], 0, -3) * 1000); // by 1000 to xlate from KB from proc file to B
+    return round(substr($m['MemTotal'], 0, -4) * 1000); // by 1000 to xlate from KB from proc file to B
 }
 
 /*


### PR DESCRIPTION
Remove empty spaces and kB from string value to avoid warning error.

A non well formed numeric value encountered in /home/rconfig/config/functions.inc.php