### PR TITLE
Update rconfigfunctions.js

### DIFF
--- a/www/js/rconfigFunctions.js
+++ b/www/js/rconfigFunctions.js
@@ -13,7 +13,7 @@ function writeConsole(content, filePath) {
 
 function openHelp() {
 
-    window.open('https://www.rconfig.com/help',
+    window.open('http://help.rconfig.com/',
             'rConfig - Documentation',
             'width=, \
             height=800, \


### PR DESCRIPTION
The help link in all the pages is going to a non-existent page (404) changed line 16 to reflect the change:
From: "window.open('https://www.rconfig.com/help',"
To: window.open('http://help.rconfig.com/',